### PR TITLE
Expose .pow10 convenience initializer 

### DIFF
--- a/Sources/Integer Conversion.swift
+++ b/Sources/Integer Conversion.swift
@@ -38,6 +38,10 @@ extension Number {
             self.init(words: source.words)
         }
     }
+
+    public init(_ integer: Number) {
+        self.init(words: integer.words)
+    }
 }
 
 extension SNumber {

--- a/Tests/NumberTests/NumberTests.swift
+++ b/Tests/NumberTests/NumberTests.swift
@@ -1576,6 +1576,7 @@ class NumberTests: XCTestCase {
         let sNumber = number.asSNumber
         let int = try? number.toInt()
         XCTAssertEqual(int, 123456789)
+        XCTAssertEqual(sNumber, SNumber(123456789))
     }
 
     func testConversionsToInt() {
@@ -1592,6 +1593,9 @@ class NumberTests: XCTestCase {
     func testPow10() {
         let number = Number.pow10(18)
         XCTAssertEqual(number, Number("1000000000000000000"))
+
+        let number2 = Number(.pow10(18))
+        XCTAssertEqual(number2, Number("1000000000000000000"))
     }
 
     func testStringAndPrecision() {

--- a/Tests/NumberTests/SNumberTests.swift
+++ b/Tests/NumberTests/SNumberTests.swift
@@ -762,5 +762,8 @@ class SNumberTests: XCTestCase {
     func testPow10() {
         let number = SNumber.pow10(18)
         XCTAssertEqual(number, SNumber("1000000000000000000"))
+
+        let number2 = SNumber(.pow10(18))
+        XCTAssertEqual(number2, SNumber("1000000000000000000"))
     }
 }


### PR DESCRIPTION
In the iOS codebase, we do this a lot: 

```
Amount(.pow10(6), decimals: 6) 
```

This was working with BigUInt, but the switch to number caused a regression because the correct initializer didn't exist. This adds the initializer and adds a test for it