### PR TITLE
Fix Number Coercions

### DIFF
--- a/Sources/Number+Conversions.swift
+++ b/Sources/Number+Conversions.swift
@@ -8,17 +8,33 @@
 
 public extension Number {
     enum ConversionError: Error {
-        case sNumberTooLarge
+        case numberTooLarge
     }
 
+    /// Returns an SNumber, which is always safe
     var asSNumber: SNumber {
         SNumber(self)
     }
 
-    func toInt() throws -> Int {
-        guard self <= Number(Int.max) else {
-            throw ConversionError.sNumberTooLarge
+    /// Returns a UInt, returning nil on a conversion failure
+    var uInt: UInt? {
+        if self <= Number(UInt.max) {
+            UInt(self)
+        } else {
+            nil
         }
-        return Int(self)
+    }
+
+    /// Returns a UInt, panicking on conversion failure
+    var asUInt: UInt {
+        try! toUInt()
+    }
+
+    /// Returns a UInt, throwing on conversion failure
+    func toUInt() throws -> UInt {
+        guard self <= Number(UInt.max) else {
+            throw ConversionError.numberTooLarge
+        }
+        return UInt(self)
     }
 }

--- a/Sources/SNumber+Conversions.swift
+++ b/Sources/SNumber+Conversions.swift
@@ -26,6 +26,22 @@ public extension SNumber {
         Number(self)
     }
 
+    /// Returns an Int, returning nil on conversion failure
+    var int: Int? {
+        guard self <= SNumber(Int.max) else {
+            return nil
+        }
+        guard self >= SNumber(Int.min) else {
+            return nil
+        }
+        return Int(self)
+    }
+
+    /// Returns an Int, panicking on conversion failure
+    var asInt: Int {
+        try! toInt()
+    }
+
     /// Returns an Int, throwing on conversion failure
     func toInt() throws -> Int {
         guard self <= SNumber(Int.max) else {

--- a/Tests/NumberTests/NumberTests.swift
+++ b/Tests/NumberTests/NumberTests.swift
@@ -1572,21 +1572,29 @@ class NumberTests: XCTestCase {
     }
 
     func testConversionsToSNumber() {
-        let number = Number(123456789)
+        let number = Number(123_456_789)
         let sNumber = number.asSNumber
-        let int = try? number.toInt()
-        XCTAssertEqual(int, 123456789)
+        let int = try? number.toUInt()
+        XCTAssertEqual(int, 123_456_789)
     }
 
-    func testConversionsToInt() {
-        let number = Number(123456789)
-        let int = try? number.toInt()
-        XCTAssertEqual(int, 123456789)
+    func testConversionsToUInt() {
+        let number = Number(123_456_789)
+        let int = try? number.toUInt()
+        XCTAssertEqual(int, 123_456_789)
 
         let number2 = Number("99999999999999999999999999999999999999999999999999999999")
-        XCTAssertThrowsError(try number2.toInt()) { error in
-            XCTAssertEqual(error as? Number.ConversionError, Number.ConversionError.sNumberTooLarge)
+        XCTAssertThrowsError(try number2.toUInt()) { error in
+            XCTAssertEqual(error as? Number.ConversionError, Number.ConversionError.numberTooLarge)
         }
+    }
+
+    func testConversionsToUIntProperty() {
+        let number1 = Number(123_456_789)
+        XCTAssertEqual(number1.uInt, 123_456_789)
+
+        let number2 = Number("99999999999999999999999999999999999999999999999999999999")
+        XCTAssertEqual(number2.uInt, nil)
     }
 
     func testPow10() {

--- a/Tests/NumberTests/SNumberTests.swift
+++ b/Tests/NumberTests/SNumberTests.swift
@@ -729,9 +729,9 @@ class SNumberTests: XCTestCase {
     }
 
     func testConversionsToNumber() {
-        let number = SNumber(123456789)
+        let number = SNumber(123_456_789)
         let number2 = number.asNumber
-        XCTAssertEqual(number2, Number(123456789))
+        XCTAssertEqual(number2, Number(123_456_789))
 
         let number3 = SNumber(-10)
         XCTAssertThrowsError(try number3.toNumber()) { error in
@@ -740,13 +740,13 @@ class SNumberTests: XCTestCase {
     }
 
     func testConversionsToInt() {
-        let number = SNumber(123456789)
+        let number = SNumber(123_456_789)
         let int = try? number.toInt()
-        XCTAssertEqual(int, 123456789)
+        XCTAssertEqual(int, 123_456_789)
 
-        let number2 = SNumber(-123456789)
+        let number2 = SNumber(-123_456_789)
         let int2 = try? number2.toInt()
-        XCTAssertEqual(int2, -123456789)
+        XCTAssertEqual(int2, -123_456_789)
 
         let number3 = SNumber("99999999999999999999999999999999999999999999999999999999")
         XCTAssertThrowsError(try number3.toInt()) { error in
@@ -757,6 +757,20 @@ class SNumberTests: XCTestCase {
         XCTAssertThrowsError(try number4.toInt()) { error in
             XCTAssertEqual(error as? SNumber.ConversionError, SNumber.ConversionError.sNumberTooSmall)
         }
+    }
+
+    func testConversionsToIntProerty() {
+        let number1 = SNumber(123_456_789)
+        XCTAssertEqual(number1.int, 123_456_789)
+
+        let number2 = SNumber(-123_456_789)
+        XCTAssertEqual(number2.int, -123_456_789)
+
+        let number3 = SNumber("99999999999999999999999999999999999999999999999999999999")
+        XCTAssertEqual(number3.int, nil)
+
+        let number4 = SNumber("-99999999999999999999999999999999999999999999999999999999")
+        XCTAssertEqual(number4.int, nil)
     }
 
     func testPow10() {


### PR DESCRIPTION
Here we work on our coercions, e.g. from a `Number` to a `UInt` (was previsouly and incorrectly to `Int`), and we add three flavors of each:

1) `number.uInt`, returns a `UInt?`
2) `number.asUInt`, returns a `UInt` or panics
3) `number.toUInt()`, returns a `UInt` or throws.

These give callers access to whichever flavor they like. We similarly add `snumber.int`, `snumber.asInt` and `snumber.toInt()`.