### PR TITLE
Add `Number` -> `Int` Conversions

### DIFF
--- a/Sources/Number+Conversions.swift
+++ b/Sources/Number+Conversions.swift
@@ -37,4 +37,26 @@ public extension Number {
         }
         return UInt(self)
     }
+
+    /// Returns an Int, returning nil on a conversion failure
+    var int: Int? {
+        if self <= Number(Int.max) {
+            Int(self)
+        } else {
+            nil
+        }
+    }
+
+    /// Returns an Int, panicking on conversion failure
+    var asInt: Int {
+        try! toInt()
+    }
+
+    /// Returns an Int, throwing on conversion failure
+    func toInt() throws -> Int {
+        guard self <= Number(Int.max) else {
+            throw ConversionError.numberTooLarge
+        }
+        return Int(self)
+    }
 }

--- a/Tests/NumberTests/NumberTests.swift
+++ b/Tests/NumberTests/NumberTests.swift
@@ -1597,6 +1597,33 @@ class NumberTests: XCTestCase {
         XCTAssertEqual(number2.uInt, nil)
     }
 
+    func testConversionsToInt() {
+        let number = Number(123_456_789)
+        let int = try? number.toInt()
+        XCTAssertEqual(int, 123_456_789)
+
+        let number2 = Number("99999999999999999999999999999999999999999999999999999999")
+        XCTAssertThrowsError(try number2.toInt()) { error in
+            XCTAssertEqual(error as? Number.ConversionError, Number.ConversionError.numberTooLarge)
+        }
+
+        let number3 = Number(UInt(Int.max))
+        XCTAssertNotNil(try? number3.toInt())
+
+        let number4 = Number(UInt(Int.max) + 1)
+        XCTAssertThrowsError(try number4.toInt()) { error in
+            XCTAssertEqual(error as? Number.ConversionError, Number.ConversionError.numberTooLarge)
+        }
+    }
+
+    func testConversionsToIntProperty() {
+        let number1 = Number(123_456_789)
+        XCTAssertEqual(number1.int, 123_456_789)
+
+        let number2 = Number("99999999999999999999999999999999999999999999999999999999")
+        XCTAssertEqual(number2.int, nil)
+    }
+
     func testPow10() {
         let number = Number.pow10(18)
         XCTAssertEqual(number, Number("1000000000000000000"))


### PR DESCRIPTION
This patch adds conversions from `Number` to `Int`. While `Number` to `UInt` makes more sense, converting from a `UInt` to an `Int` isn't always super convenient, so this is a nice little addition