### PR TITLE
Bump iOS min target to 16

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     name: "SwiftNumber",
     platforms: [
         .macOS(.v13),
-        .iOS(.v13),
+        .iOS(.v16),
         .tvOS(.v13),
         .watchOS(.v4),
         .macCatalyst(.v13),


### PR DESCRIPTION
`String.split` is used in this package but it's only available from iOS 16. In order to use this in the iOS project, need to bump the version